### PR TITLE
Fix py_vollib import error

### DIFF
--- a/options_calculator.py
+++ b/options_calculator.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 from py_vollib.black_scholes import black_scholes
-from py_vollib.black_scholes.greeks import delta, gamma, theta, vega, rho
+from py_vollib.black_scholes.greeks.analytical import delta, gamma, theta, vega, rho
 from datetime import datetime, timedelta
 import yfinance as yf
 from config import Config


### PR DESCRIPTION
Fix `ImportError` for `py_vollib` Greeks by updating the import path.

The `ImportError` occurred because the `delta`, `gamma`, `theta`, `vega`, and `rho` functions are now located in the `py_vollib.black_scholes.greeks.analytical` submodule in `py_vollib` version 1.0.1, which is specified in `requirements.txt`.

---
<a href="https://cursor.com/background-agent?bcId=bc-10bdd524-e5ab-4910-9bd4-9519387f500b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10bdd524-e5ab-4910-9bd4-9519387f500b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>